### PR TITLE
Add CT-e distribution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,40 @@ console.log(consulta)
 // }
 ```
 
+## Distribuição de CT-e
+
+### Construtor
+
+```js
+new DistribuicaoCTe(config)
+```
+
+- `config` `<Object>`
+  - Mesmo formato utilizado em `DistribuicaoDFe` para certificado A1.
+
+#### Exemplo
+
+```js
+const { DistribuicaoCTe } = require('node-mde')
+const fs = require('fs')
+
+const distribuicao = new DistribuicaoCTe({
+  pfx: fs.readFileSync('./certificado.pfx'),
+  passphrase: 'senha',
+  cnpj: '12345678901234',
+  cUFAutor: '41',
+  tpAmb: '2',
+})
+
+const consulta = await distribuicao.consultaUltNSU('000000000000000')
+
+if (consulta.error) {
+  throw new Error(consulta.error)
+}
+
+console.log(consulta)
+```
+
 ## Manifestação do Destinatário
 
 ### Construtor

--- a/src/apis/distribuicaoCte-api.js
+++ b/src/apis/distribuicaoCte-api.js
@@ -1,0 +1,132 @@
+'use strict'
+
+const { DistribuicaoCteController } = require('../controllers')
+const {
+  AmbienteValidator,
+  CertificadoValidator,
+  ChaveCteValidator,
+  CnpjCpfValidator,
+  NsuValidator,
+  UfValidator,
+} = require('../validators')
+
+class DistribuicaoCTe {
+  /**
+   * @param {Object} config
+   * @param {Buffer} [config.pfx]
+   * @param {string} [config.passphrase]
+   * @param {Buffer | string} [config.cert]
+   * @param {Buffer | string} [config.key]
+   * @param {'11' | '12' | '13' | '14' | '15' | '16' | '17' | '21' | '22' | '23' | '24' | '25' | '26' | '27' | '28' | '29' | '31' | '32' | '33' | '35' | '41' | '42' | '43' | '50' | '51' | '52' | '53'} config.cUFAutor
+   * @param {string} [config.cnpj]
+   * @param {string} [config.cpf]
+   * @param {'1' | '2'} config.tpAmb
+   * @param {Object} [config.options]
+   * @param {import('axios').AxiosRequestConfig} [config.options.requestOptions]
+   * @param {import('https').AgentOptions} [config.options.httpsOptions]
+   */
+  constructor(config) {
+    const { requestOptions = {}, httpsOptions = {} } = config.options || {}
+
+    const certificadoValidator = new CertificadoValidator(config)
+    const ambienteValidator = new AmbienteValidator(config)
+    const cnpjCpfValidator = new CnpjCpfValidator(config)
+    const ufValidator = new UfValidator(config)
+
+    if (!certificadoValidator.isValid()) {
+      throw new Error(certificadoValidator.getError())
+    }
+
+    if (!ambienteValidator.isValid()) {
+      throw new Error(ambienteValidator.getError())
+    }
+
+    if (!cnpjCpfValidator.isValid()) {
+      throw new Error(cnpjCpfValidator.getError())
+    }
+
+    if (!ufValidator.isValid()) {
+      throw new Error(ufValidator.getError())
+    }
+
+    const { cert, key } = certificadoValidator.getValues()
+    const { tpAmb } = ambienteValidator.getValues()
+    const { cnpj, cpf } = cnpjCpfValidator.getValues()
+    const { cUFAutor } = ufValidator.getValues()
+
+    this.config = Object.freeze({
+      cUFAutor: cUFAutor,
+      cnpj: cnpj,
+      cpf: cpf,
+      tpAmb: tpAmb,
+      cert: cert,
+      key: key,
+      requestOptions: Object.freeze(requestOptions),
+      httpsOptions: Object.freeze(httpsOptions),
+    })
+
+    Object.freeze(this)
+  }
+
+  /**
+   * @param {string} chCTe
+   */
+  consultaChCTe(chCTe) {
+    const chaveValidator = new ChaveCteValidator(chCTe)
+
+    if (!chaveValidator.isValid()) {
+      throw new Error(chaveValidator.getError())
+    }
+
+    const value = chaveValidator.getValues()
+
+    const opts = {
+      ...this.config,
+      chCTe: value,
+    }
+
+    return DistribuicaoCteController.enviar(opts)
+  }
+
+  /**
+   * @param {string} nsu
+   */
+  consultaNSU(nsu) {
+    const nsuValidator = new NsuValidator(nsu)
+
+    if (!nsuValidator.isValid()) {
+      throw new Error(nsuValidator.getError())
+    }
+
+    const value = nsuValidator.getValues()
+
+    const opts = {
+      ...this.config,
+      nsu: value,
+    }
+
+    return DistribuicaoCteController.enviar(opts)
+  }
+
+  /**
+   * @param {string} ultNSU
+   */
+  consultaUltNSU(ultNSU) {
+    const nsuValidator = new NsuValidator(ultNSU)
+
+    if (!nsuValidator.isValid()) {
+      throw new Error(nsuValidator.getError())
+    }
+
+    const value = nsuValidator.getValues()
+
+    const opts = {
+      ...this.config,
+      ultNSU: value,
+    }
+
+    return DistribuicaoCteController.enviar(opts)
+  }
+}
+
+module.exports = DistribuicaoCTe

--- a/src/controllers/distribuicaoCte-controller.js
+++ b/src/controllers/distribuicaoCte-controller.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { DistribuicaoCteHelper, RetornoHelper } = require('../helpers')
+
+class DistribuicaoCteController {
+  /**
+   *
+   * @param {Object} opts
+   * @returns {Promise<{data:{tpAmb: string,verAplic: string,cStat: string,xMotivo: string,dhResp: string,ultNSU: string,maxNSU: string, docZip:[{xml: string,json: Object,nsu: string,schema: string}]}, error: string, reqXml: string, resXml: string, status: number}>}
+   */
+  static async enviar(opts) {
+    const data = DistribuicaoCteHelper.montarRequest(opts)
+
+    const retornoSefaz = await DistribuicaoCteHelper.enviarConsulta(data, opts)
+
+    const json = await DistribuicaoCteHelper.montarResponse(retornoSefaz.data)
+
+    const retorno = RetornoHelper.montarRetorno({
+      json: json,
+      data: data,
+      retornoSefaz: retornoSefaz,
+    })
+
+    return retorno
+  }
+}
+
+module.exports = Object.freeze(DistribuicaoCteController)

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,10 +1,12 @@
 'use strict'
 
 const DistribuicaoController = require('./distribuicaoDFe-controller')
+const DistribuicaoCteController = require('./distribuicaoCte-controller')
 const RecepcaoController = require('./recepcaoEvento-controller')
 
 const controller = Object.freeze({
   DistribuicaoController,
+  DistribuicaoCteController,
   RecepcaoController,
 })
 

--- a/src/env/distribuicao-cte.js
+++ b/src/env/distribuicao-cte.js
@@ -1,0 +1,10 @@
+/**
+ * URL Serviço CTeDistribuicaoDFe
+ * Página Principal > Serviços > Relação de Serviços Web > Ambiente Nacional - (AN)
+ */
+const DISTRIBUICAO_CTE = {
+  1: 'https://www1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx?wsdl',
+  2: 'https://hom1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx?wsdl',
+}
+
+module.exports = { DISTRIBUICAO_CTE }

--- a/src/env/index.js
+++ b/src/env/index.js
@@ -1,5 +1,6 @@
 const { CA } = require('./ca')
 const { DISTRIBUICAO } = require('./distribuicao')
+const { DISTRIBUICAO_CTE } = require('./distribuicao-cte')
 const { EVENTOS } = require('./evento')
 const { RECEPCAO } = require('./recepcao')
 const { CODIGOS_UF } = require('./uf')
@@ -10,6 +11,7 @@ module.exports = {
   CA: CA,
   CODIGOS_UF: CODIGOS_UF,
   DISTRIBUICAO: DISTRIBUICAO,
+  DISTRIBUICAO_CTE: DISTRIBUICAO_CTE,
   EVENTOS: EVENTOS,
   RECEPCAO: RECEPCAO,
   VERSION: VERSION,

--- a/src/helpers/distribuicaoCte-helper.js
+++ b/src/helpers/distribuicaoCte-helper.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const { CA, DISTRIBUICAO_CTE } = require('../env')
+const { DistribuicaoCteSchema } = require('../schemas')
+const SefazService = require('../services/sefaz-service')
+const { Gzip, Xml } = require('../util')
+
+class DistribuicaoCteHelper {
+  /**
+   *
+   * @param {string} data
+   * @param {Object} opts
+   * @returns
+   */
+  static async enviarConsulta(data, opts) {
+    const baseURL = DISTRIBUICAO_CTE[opts.tpAmb]
+    const options = {
+      method: 'POST',
+      data: data,
+    }
+
+    const client = new SefazService({
+      baseURL: baseURL,
+      ca: CA,
+      cert: opts.cert,
+      key: opts.key,
+      tpAmb: opts.tpAmb,
+      requestOptions: opts.requestOptions,
+      httpsOptions: opts.httpsOptions,
+    })
+
+    const retorno = await client.request(options)
+
+    return retorno
+  }
+
+  /**
+   *
+   * @param {Object} opts
+   * @returns {string}
+   */
+  static montarRequest(opts) {
+    const schema = DistribuicaoCteSchema.montarSchema(opts)
+    const xml = Xml.jsonToXml(schema)
+    const data = Xml.envelopar(xml)
+
+    return data
+  }
+
+  /**
+   *
+   * @param {string} data
+   * @returns {Promise<{tpAmb: string,verAplic: string,cStat: string,xMotivo: string,dhResp: string,ultNSU: string,maxNSU: string, docZip:[{xml: string,json: Object,nsu: string,schema: string}], error: string}>}
+   */
+  static async montarResponse(data) {
+    const retorno = {}
+
+    const json = Xml.xmlToJson(data)
+
+    if (json.error) {
+      retorno['error'] = json.error
+    }
+
+    const {
+      'soap:Envelope': {
+        'soap:Body': {
+          cteDistDFeInteresseResponse: {
+            cteDistDFeInteresseResult: { retDistDFeInt = {} } = {},
+          } = {},
+        } = {},
+      } = {},
+    } = json
+
+    const { loteDistDFeInt = {} } = retDistDFeInt
+
+    if (loteDistDFeInt.docZip) {
+      if (!Array.isArray(loteDistDFeInt.docZip)) {
+        loteDistDFeInt['docZip'] = [loteDistDFeInt.docZip]
+      }
+    } else {
+      loteDistDFeInt['docZip'] = []
+    }
+
+    const docZip = await Promise.all(
+      loteDistDFeInt['docZip'].map(async (doc) => {
+        const notaXml = await Gzip.unzip(doc.value)
+        const notaJson = Xml.xmlToJson(notaXml)
+        return {
+          xml: notaXml,
+          json: notaJson,
+          nsu: doc['@_NSU'],
+          schema: doc['@_schema'],
+        }
+      })
+    )
+
+    retorno['tpAmb'] = retDistDFeInt.tpAmb || ''
+    retorno['verAplic'] = retDistDFeInt.verAplic || ''
+    retorno['cStat'] = retDistDFeInt.cStat || ''
+    retorno['xMotivo'] = retDistDFeInt.xMotivo || ''
+    retorno['dhResp'] = retDistDFeInt.dhResp || ''
+    retorno['ultNSU'] = retDistDFeInt.ultNSU || ''
+    retorno['maxNSU'] = retDistDFeInt.maxNSU || ''
+
+    retorno['docZip'] = docZip
+
+    return retorno
+  }
+}
+
+module.exports = Object.freeze(DistribuicaoCteHelper)

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
 const DistribuicaoHelper = require('./distribuicaoDFe-helper')
+const DistribuicaoCteHelper = require('./distribuicaoCte-helper')
 const RecepcaoHelper = require('./recepcaoEvento-helper')
 const RetornoHelper = require('./retorno-helper')
 
 const helper = Object.freeze({
   DistribuicaoHelper,
+  DistribuicaoCteHelper,
   RecepcaoHelper,
   RetornoHelper,
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,21 @@
 'use strict'
 
 const DistribuicaoDFe = require('./apis/distribuicaoDFe-api')
+const DistribuicaoCTe = require('./apis/distribuicaoCte-api')
 const RecepcaoEvento = require('./apis/recepcaoEvento-api')
 
 module.exports = {
   DistribuicaoDFe: DistribuicaoDFe,
+  DistribuicaoCTe: DistribuicaoCTe,
   RecepcaoEvento: RecepcaoEvento,
 }
 module.exports.default = {
   DistribuicaoDFe: DistribuicaoDFe,
+  DistribuicaoCTe: DistribuicaoCTe,
   RecepcaoEvento: RecepcaoEvento,
 }
 module.exports.mde = {
   DistribuicaoDFe: DistribuicaoDFe,
+  DistribuicaoCTe: DistribuicaoCTe,
   RecepcaoEvento: RecepcaoEvento,
 }

--- a/src/schemas/distribuicaoCte-schema.js
+++ b/src/schemas/distribuicaoCte-schema.js
@@ -1,0 +1,44 @@
+'use strict'
+
+class DistribuicaoCteSchema {
+  static montarSchema(options) {
+    const distDFeInt = {
+      tpAmb: options.tpAmb,
+      cUFAutor: options.cUFAutor,
+    }
+
+    if (options.cnpj) {
+      distDFeInt['CNPJ'] = options.cnpj
+    } else {
+      distDFeInt['CPF'] = options.cpf
+    }
+
+    if (options.ultNSU) {
+      distDFeInt['distNSU'] = {
+        ['ultNSU']: options.ultNSU,
+      }
+    } else if (options.chCTe) {
+      distDFeInt['consChCTe'] = {
+        ['chCTe']: options.chCTe,
+      }
+    } else {
+      distDFeInt['consNSU'] = {
+        ['NSU']: options.nsu,
+      }
+    }
+
+    distDFeInt['@_xmlns'] = 'http://www.portalfiscal.inf.br/cte'
+    distDFeInt['@_versao'] = '1.00'
+
+    return {
+      cteDistDFeInteresse: {
+        cteDadosMsg: {
+          distDFeInt: distDFeInt,
+        },
+        '@_xmlns': 'http://www.portalfiscal.inf.br/cte/wsdl/CTeDistribuicaoDFe',
+      },
+    }
+  }
+}
+
+module.exports = Object.freeze(DistribuicaoCteSchema)

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -2,10 +2,12 @@
 
 const DistribuicaoSchema = require('./distribuicaoDFe-schema')
 const RecepcaoSchema = require('./recepcaoEvento-schema')
+const DistribuicaoCteSchema = require('./distribuicaoCte-schema')
 
 const schema = Object.freeze({
   DistribuicaoSchema,
   RecepcaoSchema,
+  DistribuicaoCteSchema,
 })
 
 module.exports = schema

--- a/src/validators/chave-cte-validator.js
+++ b/src/validators/chave-cte-validator.js
@@ -1,0 +1,38 @@
+'use strict'
+
+class ChaveCteValidator {
+  /**
+   *
+   * @param {string} chave
+   */
+  constructor(chave) {
+    this.chave = chave
+    this.error = ''
+  }
+
+  isValid() {
+    if (!this.chave) {
+      this.error = 'Chave do CT-e não informada.'
+      return false
+    }
+
+    this.chave = String(this.chave)
+
+    if (this.chave.length !== 44) {
+      this.error = 'Chave do CT-e com tamanho incorreto.'
+      return false
+    }
+
+    return true
+  }
+
+  getValues() {
+    return this.chave
+  }
+
+  getError() {
+    return this.error
+  }
+}
+
+module.exports = Object.freeze(ChaveCteValidator)

--- a/src/validators/index.js
+++ b/src/validators/index.js
@@ -3,6 +3,7 @@
 const AmbienteValidator = require('./ambiente-validator')
 const CertificadoValidator = require('./certificado-validator')
 const ChaveValidator = require('./chave-validator')
+const ChaveCteValidator = require('./chave-cte-validator')
 const CnpjCpfValidator = require('./cnpjCpf-validator')
 const EventoValidator = require('./evento-validator')
 const LoteValidator = require('./lote-validator')
@@ -14,6 +15,7 @@ const validator = Object.freeze({
   AmbienteValidator,
   CertificadoValidator,
   ChaveValidator,
+  ChaveCteValidator,
   CnpjCpfValidator,
   EventoValidator,
   LoteValidator,

--- a/test/distribuicaoCte.test.js
+++ b/test/distribuicaoCte.test.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const assert = require('assert')
+const { DistribuicaoCTe } = require('../src')
+
+describe('DistribuicaoCTe', function () {
+  describe('#constructor()', function () {
+    it('Objeto instanciado com dados mínimos', function () {
+      const config = {
+        cert: '',
+        key: '',
+        cnpj: '12345678901234',
+        cUFAutor: '41',
+        tpAmb: '2',
+      }
+
+      const distribuicao = new DistribuicaoCTe(config)
+      assert.ok(distribuicao)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- support CT-e distribution using certificate A1
- add CT-e environment constants
- implement CT-e helper, controller, API and schema
- export new API in main module
- document CT-e usage
- add basic CT-e test

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403450192c83299cf997f11f7709a5